### PR TITLE
Make os-universal sed usage in "gulp build"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,8 @@ gulp.task('build', () => {
     run(`
         mkdir dist ;
         cp -r Koha dist/. ;
-        sed -i -e "s/{VERSION}/${package_json.version}/g" ${pm_file_path_full_dist} ;
-        sed -i -e "s/1900-01-01/${today}/g" ${pm_file_path_full_dist} ;
+        sed -i -- "s/{VERSION}/${package_json.version}/g" ${pm_file_path_full_dist} ;
+        sed -i -- "s/1900-01-01/${today}/g" ${pm_file_path_full_dist} ;
         cd dist ;
         zip -r ../${release_filename} ./Koha ;
         cd .. ;


### PR DESCRIPTION
("sed -i --" instead of "sed -i -e")
This is for be able to manually build and produce
proper versioned .kpz on MacOS