### PR TITLE
Fix 500 error that happens when you did not select a module.

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/PatronEmailer.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/PatronEmailer.pm
@@ -178,11 +178,8 @@ sub tool_step2 {
         $is_html       = $self->retrieve_data('is_html');
         $letter_code   = "BUILT_IN";
     } else {
-        my $branchcode = $cgi->param("branchcode");
-        my $module = $cgi->param("module");
-        my $letter = $cgi->param("letter");
-        warn " $branchcode and $module and $letter ";
-        $notice = Koha::Notice::Templates->find({ branchcode => $branchcode, module => $module, code => $letter });
+        my $letter_id = $cgi->param("letter");
+        $notice = Koha::Notice::Templates->find({ id => $letter_id });
         $body_template = $notice->content;
         $subject       = $notice->title;
         $letter_code   = $notice->code;

--- a/Koha/Plugin/Com/ByWaterSolutions/PatronEmailer/tool-step1.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/PatronEmailer/tool-step1.tt
@@ -68,7 +68,7 @@
             <select id="letter" name="letter">
                 <option value="">Please choose a letter</option>
                 [% FOREACH letter IN letters %]
-                    <option data-branch="[% letter.branchcode | html %]" data-module="[% letter.module | html %]" value="[% letter.code | html %]">[% letter.name | html %] ( [% Branches.GetName(letter.branchcode) || "All" | html %] | [% letter.module | html %] | [% letter.message_transport_type | html %] ) </option>
+                    <option data-branch="[% letter.branchcode | html %]" data-module="[% letter.module | html %]" value="[% letter.id | html %]">[% letter.name | html %] ( [% Branches.GetName(letter.branchcode) || "All" | html %] | [% letter.module | html %] | [% letter.message_transport_type | html %] ) </option>
                 [% END %]
             </select>
             </br>


### PR DESCRIPTION
Old way to find Letter Template returned multiple matches,
because same letter code, module, branch often had print and email
and more (sms) versions, but now it refers particular template by ID.