### PR TITLE
Remove useless scheduled CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
       - master
     tags:
       - 'v*.*.*'
-  schedule:
-    - cron: "0 6 * * *"
 jobs:
   unit_tests:
     name: Run unit tests


### PR DESCRIPTION
This is now started to burn coil for all forks, daily, 3 threads for 5 minutes of CPU time, without good reason.

... please, remove this. 

Less CO₂ as well :)